### PR TITLE
Make the particle gun simulation run independent from the input file.

### DIFF
--- a/src/app/EffStudy/EffStudyApp.cxx
+++ b/src/app/EffStudy/EffStudyApp.cxx
@@ -133,22 +133,6 @@ int main(int argc,char** argv)
   G4String inputfile = ND280XMLInput->GetXMLPathFiles();
   inputfile.append(ND280XMLInput->GetXMLGenerFileName());
 
-  TFile *myfile = new TFile(inputfile,"READ"); 
-  if (!myfile->IsOpen()) {
-    const char *msg = "NEUT file is not open!";
-    const char *origin = "Main function";
-    const char *code = "if (!myfile->IsOpen())";
-    G4Exception(origin,code,FatalException,msg);
-  }
-  TTree *mytree = (TTree*)myfile->Get(ND280XMLInput->GetXMLGenerTreeName());
-  if (!mytree) {
-    const char *msg = "NEUT tree is not open!";
-    const char *origin = "Main function";
-    const char *code = "if (!mytree->IsOpen())";
-    G4Exception(origin,code,FatalException,msg);
-  }    
-
-  
   // Set BeamOn to total # of events in the tree - first event
   
   G4int MyFirstEvent = atoi(argv[4]);
@@ -156,34 +140,51 @@ int main(int argc,char** argv)
 
   G4int NEvtStep = MyStepEvent;
   G4int NEvtTot = MyFirstEvent+NEvtStep;
-  
-  if(MyFirstEvent > (mytree->GetEntries()-1)){ // MyFirstEvent starts from 0
-    G4cout << G4endl;
-    G4cout << "MyFirstEvent = " << MyFirstEvent << G4endl;
-    G4cout << "mytree->GetEntries() = " << mytree->GetEntries() << G4endl;
-    const char *msg = "First event Id exceeds the last tree event ID!";
-    const char *origin = "Main function";
-    const char *code = " if(MyFirstEvent>mytree->GetEntries())";
-    G4Exception(origin,code,FatalException,msg);
-  }
-  
-  if(NEvtTot > mytree->GetEntries()){
-    G4cout << G4endl;
-    G4cout << "MyFirstEvent = " << MyFirstEvent << G4endl;
-    G4cout << "NEvtTot = " << NEvtTot << G4endl;
-    G4cout << "mytree->GetEntries() = " << mytree->GetEntries() << G4endl;
-    const char *msg = "Tot # of simulated events > tree->GetEntries()!";
-    const char *origin = "Main function";
-    const char *code = " if(NEvtTot>mytree->GetEntries())";
-    //G4Exception(origin,code,FatalException,msg);
-    G4Exception(origin,code,JustWarning,msg);
+
+  if (ND280XMLInput->GetXMLGenerTypeName() != "ParticleGun") {
+    TFile *myfile = new TFile(inputfile,"READ"); 
+    if (!myfile->IsOpen()) {
+      const char *msg = "NEUT file is not open!";
+      const char *origin = "Main function";
+      const char *code = "if (!myfile->IsOpen())";
+      G4Exception(origin,code,FatalException,msg);
+    }
+    TTree *mytree = (TTree*)myfile->Get(ND280XMLInput->GetXMLGenerTreeName());
+    if (!mytree) {
+      const char *msg = "NEUT tree is not open!";
+      const char *origin = "Main function";
+      const char *code = "if (!mytree->IsOpen())";
+      G4Exception(origin,code,FatalException,msg);
+    }    
     
-    NEvtStep = mytree->GetEntries() - MyFirstEvent; // no -1, first event ID is 0
+    if(MyFirstEvent > (mytree->GetEntries()-1)){ // MyFirstEvent starts from 0
+      G4cout << G4endl;
+      G4cout << "MyFirstEvent = " << MyFirstEvent << G4endl;
+      G4cout << "mytree->GetEntries() = " << mytree->GetEntries() << G4endl;
+      const char *msg = "First event Id exceeds the last tree event ID!";
+      const char *origin = "Main function";
+      const char *code = " if(MyFirstEvent>mytree->GetEntries())";
+      G4Exception(origin,code,FatalException,msg);
+    }
     
-    G4cout << "Set tot # of simul events to: " << NEvtStep << G4endl;
-    G4cout << "First event: " << MyFirstEvent << G4endl;
-    G4cout << "mytree->GetEntries() = " << mytree->GetEntries() << G4endl;
-    G4cout << G4endl;
+    if(NEvtTot > mytree->GetEntries()){
+      G4cout << G4endl;
+      G4cout << "MyFirstEvent = " << MyFirstEvent << G4endl;
+      G4cout << "NEvtTot = " << NEvtTot << G4endl;
+      G4cout << "mytree->GetEntries() = " << mytree->GetEntries() << G4endl;
+      const char *msg = "Tot # of simulated events > tree->GetEntries()!";
+      const char *origin = "Main function";
+      const char *code = " if(NEvtTot>mytree->GetEntries())";
+      //G4Exception(origin,code,FatalException,msg);
+      G4Exception(origin,code,JustWarning,msg);
+      
+      NEvtStep = mytree->GetEntries() - MyFirstEvent; // no -1, first event ID is 0
+      
+      G4cout << "Set tot # of simul events to: " << NEvtStep << G4endl;
+      G4cout << "First event: " << MyFirstEvent << G4endl;
+      G4cout << "mytree->GetEntries() = " << mytree->GetEntries() << G4endl;
+      G4cout << G4endl;
+    }
   }
 
   persistencyManager->SetEventFirst(MyFirstEvent);

--- a/src/app/EffStudy/src/ExN02PrimaryGeneratorAction.cc
+++ b/src/app/EffStudy/src/ExN02PrimaryGeneratorAction.cc
@@ -81,6 +81,9 @@ ExN02PrimaryGeneratorAction::ExN02PrimaryGeneratorAction()
   ND280RootPersistencyManager* InputPersistencyManager
     = ND280RootPersistencyManager::GetInstance();
   inxml = InputPersistencyManager->GetXMLInput();
+
+  if(fGeneratorType == "Generator")
+    RooTrackerNEUT.Initialize();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/src/app/EffStudy/src/ExN02RooTrackerKinematicsGenerator.cc
+++ b/src/app/EffStudy/src/ExN02RooTrackerKinematicsGenerator.cc
@@ -35,7 +35,9 @@ ExN02RooTrackerKinematicsGenerator::ExN02RooTrackerKinematicsGenerator()
   fCurrEntry = 0;
   fneutfile = 0;
   fneutree = 0;
-  
+}
+
+void ExN02RooTrackerKinematicsGenerator::Initialize() {
   // Take inputs
 
   //ND280InputPersistencyManager* InputPersistencyManager
@@ -66,11 +68,11 @@ ExN02RooTrackerKinematicsGenerator::ExN02RooTrackerKinematicsGenerator()
     msg << "TODO: NEED TO FILL THE REACTION MODE FOR NEUT";
     G4Exception("ExN02RooTrackerKinematicsGenerator::~ExN02RooTrackerKinematicsGenerator",
                 "MyCode0002",FatalException, msg);
-  }
-  else if(inxml->GetXMLGenerTypeName()=="GENIE"){*/
+  }*/
+  if(inxml->GetXMLGenerTypeName()=="GENIE"){
     this->ReadGENIE(inputfile);
-  /*}
-  else{
+  }
+  /*else{
     G4ExceptionDescription msg;
     msg << "The generator type "<< inxml->GetXMLGenerTypeName() << " is not available";
     G4Exception("ExN02RooTrackerKinematicsGenerator::~ExN02RooTrackerKinematicsGenerator",

--- a/src/app/EffStudy/src/ExN02RooTrackerKinematicsGenerator.hh
+++ b/src/app/EffStudy/src/ExN02RooTrackerKinematicsGenerator.hh
@@ -27,6 +27,8 @@ public :
   
   ExN02RooTrackerKinematicsGenerator();
   virtual ~ExN02RooTrackerKinematicsGenerator();
+
+  void Initialize();
   
   void GeneratePrimaryVertex(G4Event *anEvent);      // Use NEUT output
 


### PR DESCRIPTION
Input file should be used only for the NEUT/GENIE simulations.
#events could now be set to any number for PG. Before it was limited to the #entries in the input file