### PR TITLE
Feature/documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## Installation
 
+0. Make sure you have sourced root and geant4 using "this_root.sh" and "geant4.sh"
+
+1. Source env_setup.sh: `source env_setup.sh` (additionnal GEANT4/CLHEP environment variables)
+
 1. Inside this folder, create an "installation" folder
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 0. Make sure you have sourced root and geant4 using "this_root.sh" and "geant4.sh"
 
-1. Source env_setup.sh: `source env_setup.sh` (additionnal GEANT4/CLHEP environment variables)
+1. Source env_setup.sh: `source env_setup.sh` (additionnal GEANT4 environment variables)
 
 1. Inside this folder, create an "installation" folder
 

--- a/env_setup.sh
+++ b/env_setup.sh
@@ -1,7 +1,14 @@
 # Setup Geant4 environment variables not defined by geant4.sh but needed by cmake
+libPath=
+
+if [ -d "$(geant4-config --prefix)/lib64" ]
+then 
+    export GEANT4_LIBRARY=$(geant4-config --prefix)/lib64
+else
+    export GEANT4_LIBRARY=$(geant4-config --prefix)/lib
+fi
 export GEANT4_INCLUDE=$(geant4-config --prefix)/include/Geant4
 export GEANT4_INSTALL_BIN=$(geant4-config --prefix)/bin
-export GEANT4_LIBRARY=$(geant4-config --prefix)/lib
 export GEANT4_LIBRARY_DIR=$(geant4-config --prefix)/lib
 
 # Setup CLHEP environment variables needed by cmake

--- a/env_setup.sh
+++ b/env_setup.sh
@@ -1,0 +1,13 @@
+# Setup Geant4 environment variables not defined by geant4.sh but needed by cmake
+export GEANT4_INCLUDE=$(geant4-config --prefix)/include/Geant4
+export GEANT4_INSTALL_BIN=$(geant4-config --prefix)/bin
+export GEANT4_LIBRARY=$(geant4-config --prefix)/lib
+export GEANT4_LIBRARY_DIR=$(geant4-config --prefix)/lib
+
+# Setup CLHEP environment variables needed by cmake
+# clhep-config returns some "" characters we need to get rid of...
+export CLHEP_BASE_DIR=$(clhep-config --prefix | sed s/\"//g)
+export CLHEP_INCLUDE_DIR=$CLHEP_BASE_DIR/include/
+export CLHEP_LIBRARY_DIR=$CLHEP_BASE_DIR/lib64/
+export CLHEP_LIB_DIR=$CLHEP_BASE_DIR/lib64/
+export LD_LIBRARY_PATH=$CLHEP_INCLUDE_DIR:$CLHEP_LIBRARY_DIR:$LD_LIBRARY_PATH

--- a/env_setup.sh
+++ b/env_setup.sh
@@ -5,9 +5,9 @@ export GEANT4_LIBRARY=$(geant4-config --prefix)/lib
 export GEANT4_LIBRARY_DIR=$(geant4-config --prefix)/lib
 
 # Setup CLHEP environment variables needed by cmake
-# clhep-config returns some "" characters we need to get rid of...
-export CLHEP_BASE_DIR=$(clhep-config --prefix | sed s/\"//g)
-export CLHEP_INCLUDE_DIR=$CLHEP_BASE_DIR/include/
-export CLHEP_LIBRARY_DIR=$CLHEP_BASE_DIR/lib64/
-export CLHEP_LIB_DIR=$CLHEP_BASE_DIR/lib64/
-export LD_LIBRARY_PATH=$CLHEP_INCLUDE_DIR:$CLHEP_LIBRARY_DIR:$LD_LIBRARY_PATH
+# Activate below if Geant4 doesn't have CLHEP built-in
+# export CLHEP_BASE_DIR=$(clhep-config --prefix | sed s/\"//g)
+# export CLHEP_INCLUDE_DIR=$CLHEP_BASE_DIR/include/
+# export CLHEP_LIBRARY_DIR=$CLHEP_BASE_DIR/lib64/
+# export CLHEP_LIB_DIR=$CLHEP_BASE_DIR/lib64/
+# export LD_LIBRARY_PATH=$CLHEP_INCLUDE_DIR:$CLHEP_LIBRARY_DIR:$LD_LIBRARY_PATH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,8 +38,8 @@ if (NOT ${GEANT_VERSION} VERSION_LESS 10.02.03)
 	set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNEW_G4")
 endif (NOT ${GEANT_VERSION} VERSION_LESS 10.02.03)
 
-find_package(CLHEP)
-pbuilder_add_ext_libraries( ${CHLEP_LIBRARIES} )
+# find_package(CLHEP)
+# pbuilder_add_ext_libraries( ${CHLEP_LIBRARIES} )
 
 #if    (VGM_FOUND)
 #  INCLUDE_DIRECTORIES(${VGM_INCLUDE_DIR})


### PR DESCRIPTION
Simplification for setting up the environment, now you just need to source your root and geant4 and the new script env_setup.sh is taking care of defining the few environment variables needed for cmake.

T2KND280Up_CLHEP.(c)sh should not be needed anymore.